### PR TITLE
Do not require a mutable self

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ impl Crc8 {
                 return Crc8{ table : table };
         }
 
-        pub fn calc(&mut self, buffer : &[u8], length: i32, crc: u8) -> u8 {
+        pub fn calc(&self, buffer : &[u8], length: i32, crc: u8) -> u8 {
                 let mut i : i32 = 0;
                 let mut crc_tmp = crc;
 


### PR DESCRIPTION
The `calc` function doesn't require a mutable self. This makes it easier to share a `Crc8` struct.

I think this is backwards compatible.
